### PR TITLE
fix(version): postgres_exporter updated to `0.12.1` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/postgres_exporter/releases
-postgres_exporter_version: '0.12.0'
+postgres_exporter_version: '0.12.1'
 postgres_exporter_archive_name: 'postgres_exporter-{{ postgres_exporter_version }}.{{ _postgres_exporter_os }}-{{ _postgres_exporter_architecture }}'
 postgres_exporter_archive_extension: 'tar.gz'
 postgres_exporter_download_url: 'https://github.com/prometheus-community/postgres_exporter/releases/download/v{{ postgres_exporter_version }}'


### PR DESCRIPTION
The upstream [postgres_exporter](https://github.com/prometheus-community/postgres_exporter/releases) released new software version - **0.12.1**!

This automated PR updates code to bring new version into repository.