### PR TITLE
fix(version): postgres_exporter updated to `0.13.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Requirements
 Role Variables
 --------------
 
-- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.12.1`).
-- `postgres_exporter_archive_name` Postgres Exporter archive name (default: `postgres_exporter-0.12.1.linux-amd64` or `postgres_exporter-0.12.0.windows-amd64`).
+- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.13.0`).
+- `postgres_exporter_archive_name` Postgres Exporter archive name (default: `postgres_exporter-0.13.0.linux-amd64` or `postgres_exporter-0.12.0.windows-amd64`).
 - `postgres_exporter_archive_extension` Postgres Exporter archive extension (default: `tar.gz`)
-- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.12.1`).
+- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.13.0`).
 - `postgres_exporter_user` and `postgres_exporter_group` Unix username and group (default: `postgres`).
 - `postgres_exporter_install_path` Path to Postgres Exporter installation directory (default: `/usr/local/bin`).
 - `postgres_exporter_data_source_name` Accepts URI form and key=value form arguments. The URI may contain the username and password to connect with. (default: `user=postgres host=/var/run/postgresql/ sslmode=disable`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/postgres_exporter/releases
-postgres_exporter_version: '0.12.1'
+postgres_exporter_version: '0.13.0'
 postgres_exporter_archive_name: 'postgres_exporter-{{ postgres_exporter_version }}.{{ _postgres_exporter_os }}-{{ _postgres_exporter_architecture }}'
 postgres_exporter_archive_extension: 'tar.gz'
 postgres_exporter_download_url: 'https://github.com/prometheus-community/postgres_exporter/releases/download/v{{ postgres_exporter_version }}'


### PR DESCRIPTION
The upstream [postgres_exporter](https://github.com/prometheus-community/postgres_exporter/releases) released new software version - **0.13.0**!

This automated PR updates code to bring new version into repository.