### PR TITLE
fix(version): postgres_exporter updated to `0.13.1` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Role Variables
 - `postgres_exporter_web_listen_address` Address to listen on for web interface and telemetry (default: `0.0.0.0`).
 - `postgres_exporter_web_listen_port` The port to bind to (default: `9187`).
 - `postgres_exporter_web_telemetry_path` The path at which to serve metrics (default: `metrics`).
+- `postgres_exporter_collectors` List of collectors to use (default: `[]`).
 - `postgres_exporter_tls_server_config` Certificate and key files for server to use to authenticate to client.
 - `postgres_exporter_http_server_config` Enable HTTP/2 support. Note that HTTP/2 is only supported with TLS.
 - `postgres_exporter_basic_auth_users` Users and password for basic authentication. Passwords are automatically hashed with bcrypt.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Requirements
 Role Variables
 --------------
 
-- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.12.1`).
-- `postgres_exporter_archive_name` Postgres Exporter archive name (default: `postgres_exporter-0.12.1.linux-amd64` or `postgres_exporter-0.12.0.windows-amd64`).
+- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.13.1`).
+- `postgres_exporter_archive_name` Postgres Exporter archive name (default: `postgres_exporter-0.13.1.linux-amd64` or `postgres_exporter-0.12.0.windows-amd64`).
 - `postgres_exporter_archive_extension` Postgres Exporter archive extension (default: `tar.gz`)
-- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.12.1`).
+- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.13.1`).
 - `postgres_exporter_user` and `postgres_exporter_group` Unix username and group (default: `postgres`).
 - `postgres_exporter_install_path` Path to Postgres Exporter installation directory (default: `/usr/local/bin`).
 - `postgres_exporter_data_source_name` Accepts URI form and key=value form arguments. The URI may contain the username and password to connect with. (default: `user=postgres host=/var/run/postgresql/ sslmode=disable`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/postgres_exporter/releases
-postgres_exporter_version: '0.12.1'
+postgres_exporter_version: '0.13.1'
 postgres_exporter_archive_name: 'postgres_exporter-{{ postgres_exporter_version }}.{{ _postgres_exporter_os }}-{{ _postgres_exporter_architecture }}'
 postgres_exporter_archive_extension: 'tar.gz'
 postgres_exporter_download_url: 'https://github.com/prometheus-community/postgres_exporter/releases/download/v{{ postgres_exporter_version }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ postgres_exporter_data_source_name: '{{ _postgres_exporter_data_source_name }}'
 postgres_exporter_web_listen_address: '0.0.0.0'
 postgres_exporter_web_listen_port: 9187
 postgres_exporter_web_telemetry_path: '/metrics'
+postgres_exporter_collectors: []
 postgres_exporter_disable_default_metrics: false
 postgres_exporter_disable_settings_metrics: false
 postgres_exporter_extend_query_path: ''

--- a/tasks/Win32NT/configure.yml
+++ b/tasks/Win32NT/configure.yml
@@ -26,6 +26,7 @@
       {%- endif %}
       {%- if postgres_exporter_disable_default_metrics | bool %} --disable-default-metrics {%- endif %}
       {%- if postgres_exporter_disable_settings_metrics | bool %} --disable-settings-metrics {%- endif %}
+      {%- for collector in postgres_exporter_collectors %} --{{ collector }} {%- endfor %}
       {%- if postgres_exporter_extend_query_path | length > 0 %} --extend.query-path {{ postgres_exporter_extend_query_path }} {%- endif %}
       --log.level {{ postgres_exporter_log_level }}
       --log.format {{ postgres_exporter_log_format }}

--- a/templates/postgres_exporter.service.j2
+++ b/templates/postgres_exporter.service.j2
@@ -16,6 +16,9 @@ ExecStart={{ postgres_exporter_install_path }}/postgres_exporter \
 {% endif %}
     --web.listen-address {{ postgres_exporter_web_listen_address }}:{{ postgres_exporter_web_listen_port }} \
     --web.telemetry-path {{ postgres_exporter_web_telemetry_path }} \
+{% for collector in postgres_exporter_collectors %}
+    --{{ collector }} \
+{% endfor %}
 {% if postgres_exporter_disable_default_metrics | bool %}
     --disable-default-metrics \
 {% endif %}


### PR DESCRIPTION
The upstream [postgres_exporter](https://github.com/prometheus-community/postgres_exporter/releases) released new software version - **0.13.1**!

This automated PR updates code to bring new version into repository.