### PR TITLE
fix(version): postgres_exporter updated to `0.15.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ Requirements
 Role Variables
 --------------
 
-- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.14.0`).
+- `postgres_exporter_version` The specific version of Postgres Exporter to download (default: `0.15.0`).
 - `postgres_exporter_archive_name` Postgres Exporter archive name.
 
   Defaults:
-  - `postgres_exporter-0.14.0.linux-amd64` (Linux)
-  - `postgres_exporter-0.14.0.windows-amd64` (Windows)
+  - `postgres_exporter-0.15.0.linux-amd64` (Linux)
+  - `postgres_exporter-0.15.0.windows-amd64` (Windows)
 
 - `postgres_exporter_archive_extension` Postgres Exporter archive extension (default: `tar.gz`)
-- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.14.0`).
+- `postgres_exporter_download_url` URL to download an archive with Postgres Exporter (default: `https://github.com/prometheus-community/postgres_exporter/releases/download/v0.15.0`).
 - `postgres_exporter_user` and `postgres_exporter_group` Unix username and group (default: `postgres`).
 - `postgres_exporter_install_path` Path to Postgres Exporter installation directory (default: `/usr/local/bin`).
 - `postgres_exporter_data_source_name` Accepts URI form and key=value form arguments. The URI may contain the username and password to connect with. (default: `user=postgres host=/var/run/postgresql/ sslmode=disable`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/postgres_exporter/releases
-postgres_exporter_version: '0.14.0'
+postgres_exporter_version: '0.15.0'
 postgres_exporter_archive_name: 'postgres_exporter-{{ postgres_exporter_version }}.{{ _postgres_exporter_os }}-{{ _postgres_exporter_architecture }}'
 postgres_exporter_archive_extension: 'tar.gz'
 postgres_exporter_download_url: 'https://github.com/prometheus-community/postgres_exporter/releases/download/v{{ postgres_exporter_version }}'


### PR DESCRIPTION
The upstream [postgres_exporter](https://github.com/prometheus-community/postgres_exporter/releases) released new software version - **0.15.0**!

This automated PR updates code to bring new version into repository.