### PR TITLE
fix(version): postgres_exporter updated to `0.18.1` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/prometheus-community/postgres_exporter/releases
-postgres_exporter_version: '0.18.0'
+postgres_exporter_version: '0.18.1'
 postgres_exporter_archive_name: 'postgres_exporter-{{ postgres_exporter_version }}.{{ __postgres_exporter_os }}-{{ __postgres_exporter_architecture }}'
 postgres_exporter_download_url: 'https://github.com/prometheus-community/postgres_exporter/releases/download/v{{ postgres_exporter_version }}'
 postgres_exporter_checksum_url: '{{ postgres_exporter_download_url }}/sha256sums.txt'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       postgres_exporter_version:
         type: 'str'
         description: 'The version of Postgres Exporter to install.'
-        default: '0.18.0'
+        default: '0.18.1'
       postgres_exporter_archive_name:
         type: 'str'
         description: 'The Postgres Exporter archive name without an extension.'


### PR DESCRIPTION
The upstream [postgres_exporter](https://github.com/prometheus-community/postgres_exporter/releases) released new software version - **0.18.1**!

This automated PR updates code to bring new version into repository.